### PR TITLE
Load three.js from CDN for LiquidEther component

### DIFF
--- a/codalumen/index.html
+++ b/codalumen/index.html
@@ -13,6 +13,10 @@
   </head>
   <body class="antialiased">
     <div id="root"></div>
+    <script
+      src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"
+      crossorigin="anonymous"
+    ></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/codalumen/src/components/LiquidEther.tsx
+++ b/codalumen/src/components/LiquidEther.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react"
-import * as THREE from "three"
 import "./LiquidEther.css"
 
 export interface LiquidEtherProps {
@@ -22,6 +21,13 @@ export interface LiquidEtherProps {
   takeoverDuration?: number
   autoResumeDelay?: number
   autoRampDuration?: number
+}
+
+function getThreeGlobal() {
+  if (typeof window === "undefined") {
+    return null
+  }
+  return (window as any).THREE ?? null
 }
 
 export default function LiquidEther({
@@ -55,6 +61,12 @@ export default function LiquidEther({
 
   useEffect(() => {
     if (!mountRef.current) return
+
+    const THREE = getThreeGlobal()
+    if (!THREE) {
+      console.error("Three.js failed to load. Ensure the global script is available.")
+      return
+    }
 
     function makePaletteTexture(stops: string[]) {
       let arr: string[]


### PR DESCRIPTION
## Summary
- load the three.js library from a CDN so LiquidEther no longer relies on a bundled dependency
- guard the LiquidEther effect to stop initialization when the global THREE object cannot be found

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68db806433c48327bef7eb5a28c7fb99