### PR TITLE
Fix LiquidEther background initialization timing

### DIFF
--- a/codalumen/index.html
+++ b/codalumen/index.html
@@ -13,10 +13,6 @@
   </head>
   <body class="antialiased">
     <div id="root"></div>
-    <script
-      src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"
-      crossorigin="anonymous"
-    ></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the LiquidEther backdrop waits for Three.js to finish loading before initialising
- add a dynamic loader that injects the Three.js script when it is not already present and track readiness in component state
- remove the static CDN script tag from index.html now that the component manages its own dependency loading

## Testing
- npm run build *(fails: tsconfig.json references tsconfig.node.json which disables emit)*
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68db82293a6483279accf5903869ada3