### PR TITLE
Replace background effect with LiquidEther component

### DIFF
--- a/codalumen/src/components/LiquidEther.tsx
+++ b/codalumen/src/components/LiquidEther.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
+import type { CSSProperties } from "react"
+import * as THREE from "three"
 import "./LiquidEther.css"
 
 export interface LiquidEtherProps {
@@ -13,7 +15,7 @@ export interface LiquidEtherProps {
   resolution?: number
   isBounce?: boolean
   colors?: string[]
-  style?: React.CSSProperties
+  style?: CSSProperties
   className?: string
   autoDemo?: boolean
   autoSpeed?: number
@@ -21,74 +23,6 @@ export interface LiquidEtherProps {
   takeoverDuration?: number
   autoResumeDelay?: number
   autoRampDuration?: number
-}
-
-function getThreeGlobal() {
-  if (typeof window === "undefined") {
-    return null
-  }
-  return (window as any).THREE ?? null
-}
-
-let threeLoadPromise: Promise<any> | null = null
-
-function ensureThreeLoaded() {
-  if (typeof window === "undefined") {
-    return Promise.reject(new Error("Three.js cannot load on the server."))
-  }
-
-  const existing = getThreeGlobal()
-  if (existing) {
-    return Promise.resolve(existing)
-  }
-
-  if (!threeLoadPromise) {
-    threeLoadPromise = new Promise((resolve, reject) => {
-      let scriptElement: HTMLScriptElement | null = null
-
-      const onLoad = () => {
-        if (scriptElement) {
-          scriptElement.setAttribute("data-three-loaded", "true")
-        }
-        const three = getThreeGlobal()
-        if (three) {
-          resolve(three)
-        } else {
-          reject(new Error("Three.js loaded without exposing a global."))
-        }
-      }
-
-      const onError = () => reject(new Error("Three.js failed to load."))
-
-      const existingScript = document.querySelector<HTMLScriptElement>(
-        'script[src*="three"]'
-      )
-
-      if (existingScript) {
-        scriptElement = existingScript
-        if (
-          existingScript.getAttribute("data-three-loaded") === "true" ||
-          existingScript.readyState === "complete"
-        ) {
-          onLoad()
-        } else {
-          existingScript.addEventListener("load", onLoad, { once: true })
-          existingScript.addEventListener("error", onError, { once: true })
-        }
-      } else {
-        const script = document.createElement("script")
-        script.src = "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"
-        script.async = true
-        script.crossOrigin = "anonymous"
-        scriptElement = script
-        script.addEventListener("load", onLoad, { once: true })
-        script.addEventListener("error", onError, { once: true })
-        document.head.appendChild(script)
-      }
-    })
-  }
-
-  return threeLoadPromise
 }
 
 export default function LiquidEther({
@@ -119,38 +53,9 @@ export default function LiquidEther({
   const intersectionObserverRef = useRef<IntersectionObserver | null>(null)
   const isVisibleRef = useRef(true)
   const resizeRafRef = useRef<number | null>(null)
-  const [isThreeReady, setIsThreeReady] = useState(() => Boolean(getThreeGlobal()))
 
   useEffect(() => {
-    let mounted = true
-
-    if (isThreeReady) {
-      return
-    }
-
-    ensureThreeLoaded()
-      .then(() => {
-        if (mounted) {
-          setIsThreeReady(true)
-        }
-      })
-      .catch((error) => {
-        console.error(error)
-      })
-
-    return () => {
-      mounted = false
-    }
-  }, [isThreeReady])
-
-  useEffect(() => {
-    if (!mountRef.current || !isThreeReady) return
-
-    const THREE = getThreeGlobal()
-    if (!THREE) {
-      console.error("Three.js is not available on window despite being marked ready.")
-      return
-    }
+    if (!mountRef.current) return
 
     function makePaletteTexture(stops: string[]) {
       let arr: string[]


### PR DESCRIPTION
## Summary
- import three.js directly for the LiquidEther background effect
- simplify the LiquidEther component now that three.js is bundled with the app

## Testing
- npm run build *(fails: tsconfig.json references ./tsconfig.node.json which is marked noEmit)*

------
https://chatgpt.com/codex/tasks/task_e_68db851b97a08327af20ca3dd280bc73