### PR TITLE
Wrap liquid background in container

### DIFF
--- a/codalumen/src/App.tsx
+++ b/codalumen/src/App.tsx
@@ -161,25 +161,27 @@ function AuroraBackdrop({ reduceMotion }: { reduceMotion: boolean }) {
   return (
     <div className="fixed inset-0 -z-10 overflow-hidden">
       {!reduceMotion ? (
-        <LiquidEther
-          className="pointer-events-none"
-          style={{ width: "100%", height: "100%", position: "absolute", inset: 0 }}
-          colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
-          mouseForce={20}
-          cursorSize={100}
-          isViscous={false}
-          viscous={30}
-          iterationsViscous={32}
-          iterationsPoisson={32}
-          resolution={0.5}
-          isBounce={false}
-          autoDemo
-          autoSpeed={0.5}
-          autoIntensity={2.2}
-          takeoverDuration={0.25}
-          autoResumeDelay={3000}
-          autoRampDuration={0.6}
-        />
+        <div style={{ width: "100%", height: "100%", position: "relative" }}>
+          <LiquidEther
+            className="pointer-events-none"
+            style={{ width: "100%", height: "100%", position: "absolute", inset: 0 }}
+            colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
+            mouseForce={20}
+            cursorSize={100}
+            isViscous={false}
+            viscous={30}
+            iterationsViscous={32}
+            iterationsPoisson={32}
+            resolution={0.5}
+            isBounce={false}
+            autoDemo
+            autoSpeed={0.5}
+            autoIntensity={2.2}
+            takeoverDuration={0.25}
+            autoResumeDelay={3000}
+            autoRampDuration={0.6}
+          />
+        </div>
       ) : (
         <div className="absolute inset-0 bg-aurora" aria-hidden />
       )}


### PR DESCRIPTION
## Summary
- wrap the LiquidEther backdrop in a relative container to match the intended usage snippet

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db8a9c1fe08327a52a0b2555017065