### PR TITLE
Improve Liquid Ether backdrop visibility

### DIFF
--- a/codalumen/src/App.tsx
+++ b/codalumen/src/App.tsx
@@ -160,28 +160,27 @@ export default function App() {
 function AuroraBackdrop({ reduceMotion }: { reduceMotion: boolean }) {
   return (
     <div className="fixed inset-0 -z-10 overflow-hidden">
+      <div className="absolute inset-0 bg-aurora opacity-70 blur-3xl" aria-hidden />
       {!reduceMotion ? (
-        <div style={{ width: "100%", height: "100%", position: "relative" }}>
-          <LiquidEther
-            className="pointer-events-none"
-            style={{ width: "100%", height: "100%", position: "absolute", inset: 0 }}
-            colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
-            mouseForce={20}
-            cursorSize={100}
-            isViscous={false}
-            viscous={30}
-            iterationsViscous={32}
-            iterationsPoisson={32}
-            resolution={0.5}
-            isBounce={false}
-            autoDemo
-            autoSpeed={0.5}
-            autoIntensity={2.2}
-            takeoverDuration={0.25}
-            autoResumeDelay={3000}
-            autoRampDuration={0.6}
-          />
-        </div>
+        <LiquidEther
+          className="pointer-events-none absolute inset-0"
+          style={{ width: "100%", height: "100%" }}
+          colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
+          mouseForce={20}
+          cursorSize={100}
+          isViscous={false}
+          viscous={30}
+          iterationsViscous={32}
+          iterationsPoisson={32}
+          resolution={0.5}
+          isBounce={false}
+          autoDemo
+          autoSpeed={0.5}
+          autoIntensity={2.2}
+          takeoverDuration={0.25}
+          autoResumeDelay={3000}
+          autoRampDuration={0.6}
+        />
       ) : (
         <div className="absolute inset-0 bg-aurora" aria-hidden />
       )}


### PR DESCRIPTION
## Summary
- add a persistent blurred aurora gradient behind the LiquidEther canvas so the landing background is visible immediately
- ensure the LiquidEther component spans the full viewport via utility classes instead of inline positioning wrappers

## Testing
- npm run build *(fails: tsconfig.json references tsconfig.node.json which may not disable emit)*

------
https://chatgpt.com/codex/tasks/task_e_68db8f9da12883279d9cf29508adc5f2