### PR TITLE
Ensure LiquidEther animation covers landing background

### DIFF
--- a/codalumen/src/App.tsx
+++ b/codalumen/src/App.tsx
@@ -165,7 +165,7 @@ function AuroraBackdrop({ reduceMotion }: { reduceMotion: boolean }) {
       {!reduceMotion ? (
         <LiquidEther
           className="pointer-events-none absolute inset-0"
-          style={{ width: "100%", height: "100%" }}
+          style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
           colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
           mouseForce={20}
           cursorSize={100}

--- a/codalumen/src/components/LiquidEther.css
+++ b/codalumen/src/components/LiquidEther.css
@@ -5,3 +5,8 @@
   height: 100%;
   touch-action: none;
 }
+
+.liquid-ether-container.absolute,
+.liquid-ether-container.fixed {
+  position: absolute;
+}


### PR DESCRIPTION
## Summary
- ensure the LiquidEther background in `AuroraBackdrop` is explicitly positioned to cover the full viewport
- update the LiquidEther container styles so Tailwind's absolute/fixed utilities can take effect for background usage

## Testing
- Not run (network restrictions prevented installing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68dc424e8ffc8327b01f115bce4e8bf7