### PR TITLE
Make aurora animation cover entire page

### DIFF
--- a/codalumen/src/App.tsx
+++ b/codalumen/src/App.tsx
@@ -164,8 +164,8 @@ function AuroraBackdrop({ reduceMotion }: { reduceMotion: boolean }) {
       <div className="absolute inset-0 bg-aurora opacity-70 blur-3xl" aria-hidden />
       {!reduceMotion ? (
         <LiquidEther
-          className="pointer-events-none absolute inset-0"
-          style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+          className="pointer-events-none fixed inset-0"
+          style={{ width: "100%", height: "100%" }}
           colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
           mouseForce={20}
           cursorSize={100}

--- a/codalumen/src/components/LiquidEther.css
+++ b/codalumen/src/components/LiquidEther.css
@@ -6,7 +6,10 @@
   touch-action: none;
 }
 
-.liquid-ether-container.absolute,
-.liquid-ether-container.fixed {
+.liquid-ether-container.absolute {
   position: absolute;
+}
+
+.liquid-ether-container.fixed {
+  position: fixed;
 }


### PR DESCRIPTION
## Summary
- allow the LiquidEther canvas to respect fixed positioning by adjusting its CSS helper classes
- update the aurora backdrop to use a fixed LiquidEther instance so the animation spans the entire landing page

## Testing
- npm run build *(fails: Cannot find type definition file for 'vite/client'; tsconfig references tsconfig.node.json which disables emit)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4a50f81c8327b4ac2e72c25b30de