### PR TITLE
Fix LiquidEther background sizing

### DIFF
--- a/codalumen/src/App.tsx
+++ b/codalumen/src/App.tsx
@@ -165,7 +165,13 @@ function AuroraBackdrop({ reduceMotion }: { reduceMotion: boolean }) {
       {!reduceMotion ? (
         <LiquidEther
           className="pointer-events-none fixed inset-0"
-          style={{ width: "100%", height: "100%" }}
+          style={{
+            position: "fixed",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            pointerEvents: "none",
+          }}
           colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
           mouseForce={20}
           cursorSize={100}
@@ -238,7 +244,7 @@ function InteractiveLiquidSection({ prefersReducedMotion }: { prefersReducedMoti
         {!prefersReducedMotion ? (
           <LiquidEther
             className="absolute inset-0"
-            style={{ width: "100%", height: "100%" }}
+            style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
             colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
             mouseForce={20}
             cursorSize={120}


### PR DESCRIPTION
## Summary
- ensure the fullscreen LiquidEther backdrop keeps its fixed viewport positioning
- pin the interactive section's LiquidEther instance to the container bounds so it renders at full size

## Testing
- npm install *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6b2b9ec48327b48a737e06079d05