### PR TITLE
Fix Aurora backdrop z-index so it renders fullscreen

### DIFF
--- a/codalumen/src/App.tsx
+++ b/codalumen/src/App.tsx
@@ -160,7 +160,7 @@ export default function App() {
 
 function AuroraBackdrop({ reduceMotion }: { reduceMotion: boolean }) {
   return (
-    <div className="fixed inset-0 -z-10 overflow-hidden">
+    <div className="fixed inset-0 z-0 overflow-hidden">
       <div className="absolute inset-0 bg-aurora opacity-70 blur-3xl" aria-hidden />
       {!reduceMotion ? (
         <LiquidEther


### PR DESCRIPTION
## Summary
- adjust the AuroraBackdrop container z-index so the global liquid effect renders behind the content instead of behind the page background

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc6d7f908c8327ab3941c406bcbf48